### PR TITLE
Add release/push functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ Temporary Items
 # cache
 __pycache__
 .idea
+
+# python
+*.pyc

--- a/sonarr/sonarr_api.py
+++ b/sonarr/sonarr_api.py
@@ -105,6 +105,22 @@ class SonarrAPI(object):
 
 
     # ENDPOINT RELEASE/PUSH
+    def push_release(self, title, downloadUrl, protocol, publishDate):
+        """Notifies Sonarr of a new release.
+            title: release name
+            downloadUrl: .torrent file URL
+            protocol: usenet / torrent
+            publishDate: ISO8601 date string
+        """
+        res = self.request_post(
+                "{}/release/push".format(self.host_url),
+                {
+                    'title': title,
+                    'downloadUrl': downloadUrl,
+                    'protocol': protocol,
+                    'publishDate': publishDate
+                })
+        return res.json()
 
 
     # ENDPOINT ROOTFOLDER


### PR DESCRIPTION
Also 2 other small fixes (*.pyc to .gitignore and __init__.py for easier importing).

Tested and it works:

```
>>> from sonarr.sonarr_api import SonarrAPI
>>> s = SonarrAPI("http://localhost:8989/api", "XXXXXXXXXXXXX")
>>> s.push_release("The.Devils.Ride.S03E01.720p.HDTV.x264-YesTV", "http://www.newshost.co.za/nzb/5a6/The.Devils.Ride.S03E01.720p.HDTV.x264-YesTV.nzb", "usenet", "2014-02-10T00:00:00Z")
{u'protocol': u'usenet', u'ageMinutes': 2229334.4792004335, u'fullSeason': False, u'isAbsoluteNumbering': False, u'tvRageId': 0, u'absoluteEpisodeNumbers': [], u'guid': u'PUSH-http://www.newshost.co.za/nzb/5a6/The.Devils.Ride.S03E01.720p.HDTV.x264-YesTV.nzb', u'quality': {u'quality': {u'id': 4, u'name': u'HDTV-720p'}, u'revision': {u'real': 0, u'version': 1}}, u'qualityWeight': 1, u'ageHours': 37155.574653340555, u'size': 0, u'downloadUrl': u'http://www.newshost.co.za/nzb/5a6/The.Devils.Ride.S03E01.720p.HDTV.x264-YesTV.nzb', u'title': u'The.Devils.Ride.S03E01.720p.HDTV.x264-YesTV', u'special': False, u'releaseHash': u'', u'indexerId': 0, u'seriesTitle': u'The Devils Ride', u'seasonNumber': 3, u'tvdbId': 0, u'temporarilyRejected': False, u'rejected': True, u'downloadAllowed': False, u'isPossibleSpecialEpisode': False, u'isDaily': False, u'publishDate': u'2014-02-10T00:00:00Z', u'approved': False, u'language': u'english', u'age': 1548, u'releaseGroup': u'YesTV', u'releaseWeight': 0, u'episodeNumbers': [1], u'rejections': [u'Unknown Series']}
```